### PR TITLE
fix: remove unsupported package-name parameter from release-please v4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,6 @@ jobs:
         id: release
         with:
           release-type: go
-          package-name: traffic-control-go
           
   # Build and upload release artifacts when a release is created
   build-release:


### PR DESCRIPTION
## Summary
- Remove the `package-name` parameter from release-please action as it's not supported in v4
- This fixes the release-please workflow failure after the recent merge

## Context
The release-please GitHub Action v4 no longer supports the `package-name` parameter. This was causing the workflow to fail with a warning about unexpected inputs.

🤖 Generated with [Claude Code](https://claude.ai/code)