### PR TITLE
fix: configure release-please to work with repository permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -16,10 +17,12 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      # Use the default GITHUB_TOKEN which has permissions based on the workflow permissions
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: go
+          token: ${{ secrets.GITHUB_TOKEN }}
           
   # Build and upload release artifacts when a release is created
   build-release:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,19 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "go",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "style", "section": "Styles"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "test", "section": "Tests"},
+        {"type": "build", "section": "Build System"},
+        {"type": "ci", "section": "Continuous Integration"},
+        {"type": "chore", "section": "Chores"}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add release-please configuration files to initialize versioning
- Improve workflow permissions and add explicit token
- This should help resolve the GitHub Actions permission issues

## Changes
1. Added `.release-please-manifest.json` with initial version 0.1.0
2. Added `release-please-config.json` with Go-specific configuration
3. Added `actions: write` permission to the workflow
4. Added explicit `token` parameter to release-please action

## Context
Release Please was failing with "GitHub Actions is not permitted to create or approve pull requests" error. This PR adds proper configuration to help release-please work within the current repository permission constraints.

## Next Steps
After merging this PR, you may still need to:
1. Go to Settings → Actions → General
2. Under "Workflow permissions", enable "Allow GitHub Actions to create and approve pull requests"

🤖 Generated with [Claude Code](https://claude.ai/code)