### PR TITLE
fix: skip labeling in release-please to avoid permission errors

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           release-type: go
           token: ${{ secrets.GITHUB_TOKEN }}
+          skip-labeling: true
           
   # Build and upload release artifacts when a release is created
   build-release:


### PR DESCRIPTION
## Summary
- Add `skip-labeling: true` to release-please action to avoid label creation permission errors

## Context
Release Please is working correctly and creating PRs, but fails at the end with:
```
release-please failed: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
```

This PR adds the `skip-labeling` option to prevent this error.

## Test
After merging, release-please should complete without errors.

🤖 Generated with [Claude Code](https://claude.ai/code)