### PR TITLE
fix: prevent auto-tag duplicates by adding seconds to timestamp

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,16 +17,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create date-based tag
+      - name: Create date-based tag and release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Generate date-based tag
-          TAG_NAME="v$(date +%Y%m%d)"
-          
-          # Check if tag already exists
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "Tag $TAG_NAME already exists, adding time suffix"
-            TAG_NAME="v$(date +%Y%m%d%H%M)"
-          fi
+          # Generate date-based tag with time
+          TAG_NAME="v$(date +%Y%m%d%H%M%S)"
           
           # Create and push tag
           git config user.name "github-actions[bot]"
@@ -36,17 +32,6 @@ jobs:
           git push origin "$TAG_NAME"
           
           echo "Created tag: $TAG_NAME"
-
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG_NAME="v$(date +%Y%m%d)"
-          
-          # Check if we used time suffix
-          if ! git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            TAG_NAME="v$(date +%Y%m%d%H%M)"
-          fi
           
           # Create release
           gh release create "$TAG_NAME" \


### PR DESCRIPTION
## Summary
- Fix auto-tag workflow failure caused by duplicate tag names
- Change tag format from `vYYYYMMDD` to `vYYYYMMDDHHMMSS`

## Problem
The auto-tag workflow was failing when multiple commits were pushed to main on the same day because it tried to create tags with the same name (e.g., `v20250603`).

## Solution
Added hours, minutes, and seconds to the tag format to ensure uniqueness. Tags will now look like `v20250603182350`.

## Changes
- Simplified the workflow by removing unnecessary duplicate tag checking
- Combined tag and release creation into a single step
- Used a more precise timestamp format

🤖 Generated with [Claude Code](https://claude.ai/code)